### PR TITLE
Small css fix to break very long nonbreaking space (ie: added word break)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -839,6 +839,7 @@ button.disabled:hover
 {
     font-size: 13px;
     margin: 2px 10px 4px 60px;
+    word-break: break-all;
 }
 .post-context
 {


### PR DESCRIPTION
Very long posts were not word breaking properly.

Before:
![selection_001](https://f.cloud.github.com/assets/6403056/1937788/180d7d9a-7f31-11e3-938b-032c4fd67568.png)

After:
![selection_002](https://f.cloud.github.com/assets/6403056/1937789/1f5e957a-7f31-11e3-8064-9ba1bd1040c7.png)
