### PR TITLE
Fix #35 - 'Posts' misplaced in profile modal if timeline was scrolled

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -705,8 +705,6 @@ button.disabled:hover
 }
 .postboard h2.fixed
 {
-    position: fixed;
-    top: 40px;
     z-index: 2;
     border-top: solid 4px #fbf9f6;
 }


### PR DESCRIPTION
This should fix miguelfreitas/twister-html#35 , can someone else please test it ?
