### PR TITLE
Fix modal direct message

### DIFF
--- a/home.html
+++ b/home.html
@@ -333,7 +333,7 @@
         <textarea placeholder="New direct message..."></textarea>
         <div class="post-area-extras">
           <span class="post-area-remaining">140</span>
-          <button class="dm-submit disabled" disabled="true">send</button>
+          <button  title="Direct messages are encrypted, only you and receiver can read them" style="margin-right:7.5%;" class="dm-submit disabled" disabled="true">send</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
before
![2014-01-24 12 47 18](https://f.cloud.github.com/assets/426427/1993334/e2d2b04e-84d7-11e3-9c97-dae77f3f06b0.png)

after: 
![2014-01-24 12 55 05](https://f.cloud.github.com/assets/426427/1993340/f7164a98-84d7-11e3-817a-10bb2350c21d.png)

and i add title text for button (i think people mast know that messages are encrypted)

![2014-01-24 13 10 05](https://f.cloud.github.com/assets/426427/1993343/1497ca7e-84d8-11e3-9198-81ee6d963a4d.png)
