### PR TITLE
Fix import key - lowercase username

### DIFF
--- a/js/twister_user.js
+++ b/js/twister_user.js
@@ -183,7 +183,7 @@ function importSecretKeypress() {
 
 function importSecretKeyClick() {
     var secretKey = $(".secret-key-import").val();
-    var username = $(".username-import").val();
+    var username = $(".username-import").val().toLowerCase();
 
     twisterRpc("importprivkey", [secretKey,username],
                function(args, ret) {


### PR DESCRIPTION
Fixes miguelfreitas/twister-core#156 – secret key import will fail when user starts typing nickname with a capital letter. The issue was reported to Core, but the conversion should be done in the UI, otherwise it would break when trying to switch to the newly imported account.
