### PR TITLE
Guest mode – browse without registration

### DIFF
--- a/home.html
+++ b/home.html
@@ -53,7 +53,7 @@
             </div>
             <a class="dropdown-menu-item" href="options.html">Options</a>
             <a class="dropdown-menu-item" href="profile-edit.html">Setup account</a>
-            <a class="dropdown-menu-item" href="following.html">Following users</a>
+            <a class="dropdown-menu-item dropdown-menu-following" href="following.html">Following users</a>
             <a class="dropdown-menu-item" href="network.html">Network config</a>
             <a class="dropdown-menu-item" href="login.html">Change user</a>
             <a class="dropdown-menu-item promoted-posts-only" href="#">Switch to Promoted posts</a>
@@ -118,8 +118,8 @@
         </div>
         <ul class="module profile-data">
           <li><a href="#" class="open-profile-modal"><span class="posts-count">&nbsp;</span><span class="label">Posts</span></a></li>
-          <li><a href="following.html"><span class="following-count">&nbsp;</span><span class="label">Following</span></a></li>
-          <li><a href="#"><span class="followers-count">&nbsp;</span><span class="label">Followers</span> *</a></li>
+          <li><a href="following.html" class="open-following-page"><span class="following-count">&nbsp;</span><span class="label">Following</span></a></li>
+          <li><a href="#" class="open-followers"><span class="followers-count">&nbsp;</span><span class="label">Followers</span> *</a></li>
         </ul>
       
         <div class="post-area">

--- a/js/interface_common.js
+++ b/js/interface_common.js
@@ -5,6 +5,8 @@
 // Profile, mentions and hashtag modal
 // Post actions: submit, count characters
 
+var preventSlide = false;
+
 //dispara o modal genérico
 //o modalClass me permite fazer tratamentos específicos de CSS para cada modal
 function openModal( modalClass )
@@ -103,6 +105,12 @@ function openProfileModal(e)
 
     var $this = $( this );
     var username = $.MAL.urlToUser( $this.attr("href") );
+    
+    if(!username)
+    {
+	alert(polyglot.t("You don't have any profile because you are not logged in."));
+	return;
+    }
 
     var profileModalClass = "profile-modal";
     openModal( profileModalClass );
@@ -169,6 +177,11 @@ function openMentionsModal(e)
     e.stopPropagation();
     e.preventDefault();
 
+    if(!defaultScreenName)
+    {
+	alert(polyglot.t("No one can mention you because you are not logged in."));
+	return;
+    }
     // reuse the same hashtag modal to show mentions
     var hashtagModalClass = "hashtag-modal";
     openModal( hashtagModalClass );
@@ -224,6 +237,13 @@ function openFollowingModal(e)
 //dispara o modal de retweet
 var reTwistPopup = function( e )
 {
+    if(!defaultScreenName)
+    {
+	preventSlide=true;
+	alert(polyglot.t("You have to log in to retransmit messages."));
+	return;
+    }
+    
     var reTwistClass = "reTwist";
     openModal( reTwistClass );
 
@@ -296,7 +316,15 @@ var postExpandFunction = function( e, postLi )
     var $postsRelated = postLi.find(".related");
 
     var openClass = "open";
-    if( !postLi.hasClass( openClass ) ) {
+    
+    //This is used in "guest mode", when user gets an alert that he can't reply or retransmit
+    //when not logged in. Otherwise, this click would also be understood as a command to open/close
+    //the post, which would look weird.
+    if(preventSlide)
+    {
+	preventSlide=false;
+    }
+    else if( !postLi.hasClass( openClass ) ) {
         originalPost.detach();
         postLi.empty();
         postLi.addClass( openClass );
@@ -347,6 +375,12 @@ var postExpandFunction = function( e, postLi )
 
 var postReplyClick = function( e )
 {
+    if(!defaultScreenName)
+    {
+	preventSlide=true;
+	alert(polyglot.t("You have to log in to post replies."));
+	return;
+    }
     var post = $(this).closest(".post");
     if( !post.hasClass( "original" ) ) {
         replyInitPopup(e, post);

--- a/js/interface_home.js
+++ b/js/interface_home.js
@@ -31,24 +31,56 @@ var InterfaceFunctions = function()
     }
 
     function initHome(cbFunc, cbArg) {
-        if( !defaultScreenName ) {
-            alert(polyglot.t("username_undefined"));
-            $.MAL.goLogin();
-            return;
-        }
         checkNetworkStatusAndAskRedirect();
 
         //$("span.screen-name").text('@' + user);
         var $miniProfile = $(".mini-profile");
-        $miniProfile.find("a.mini-profile-name").attr("href",$.MAL.userUrl(defaultScreenName));
-        $miniProfile.find("a.open-profile-modal").attr("href",$.MAL.userUrl(defaultScreenName));
-        $miniProfile.find(".mini-profile-name").text(defaultScreenName);
-        getFullname( defaultScreenName, $miniProfile.find(".mini-profile-name") );
-        getAvatar( defaultScreenName, $miniProfile.find(".mini-profile-photo").find("img") );
-        getPostsCount( defaultScreenName,  $miniProfile.find(".posts-count") );
-        getFollowers( defaultScreenName, $miniProfile.find(".followers-count") );
+        if(!defaultScreenName)
+        {
+            $(".userMenu-profile > a").text(polyglot.t("Login"));
+            $(".userMenu-profile > a").attr("href","login.html");
+            $(".post-area-new > textarea").attr("placeholder",polyglot.t("You have to log in to post messages."));
+            $(".post-area-new > textarea").attr("disabled","true");
+            $miniProfile.find(".mini-profile-name").text("guest");
+            $miniProfile.find(".posts-count").text("0");
+            $miniProfile.find(".following-count").text("0");
+            $miniProfile.find(".followers-count").text("0");
+            $miniProfile.find("a.open-following-page").attr("href","#");
+            $miniProfile.find("a.open-following-page").bind("click", function()
+            { alert(polyglot.t("You are not following anyone because you are not logged in."))} );
+            $miniProfile.find("a.open-followers").bind("click", function()
+            { alert(polyglot.t("You don't have any followers because you are not logged in."))} );
+            $(".dropdown-menu-following").attr("href","#");
+            $(".dropdown-menu-following").bind("click", function()
+            { alert(polyglot.t("You are not following anyone because you are not logged in."))} );
+            twisterRpc("gettrendinghashtags", [10],
+                                function(args, ret) {
+                                    for( var i = 0; i < ret.length; i++ ) {
+                                    
+                                       var $li = $("<li>");
+                                       var hashtagLinkTemplate = $("#hashtag-link-template").clone(true);
+                                       hashtagLinkTemplate.removeAttr("id");
+                                       hashtagLinkTemplate.attr("href",$.MAL.hashtagUrl(ret[i]));
+                                       hashtagLinkTemplate.text("#"+ret[i]);
+                                       $li.append(hashtagLinkTemplate);
+                                       $(".toptrends-list").append($li);
+                                    }
+                                }, {},
+                                function(args, ret) {
+                                   console.log("Error with gettrendinghashtags. Older twister daemon?");
+                                }, {});	    
+        }
+        else
+        {
+            $miniProfile.find("a.mini-profile-name").attr("href",$.MAL.userUrl(defaultScreenName));
+            $miniProfile.find("a.open-profile-modal").attr("href",$.MAL.userUrl(defaultScreenName));
+            $miniProfile.find(".mini-profile-name").text(defaultScreenName);
+            getFullname( defaultScreenName, $miniProfile.find(".mini-profile-name") );
+            getAvatar( defaultScreenName, $miniProfile.find(".mini-profile-photo").find("img") );
+            getPostsCount( defaultScreenName,  $miniProfile.find(".posts-count") );
+            getFollowers( defaultScreenName, $miniProfile.find(".followers-count") );
 
-        loadFollowing( function(args) {
+            loadFollowing( function(args) {
                      $(".mini-profile .following-count").text(followingUsers.length-1);
                      requestLastHave();
                      setInterval("requestLastHave()", 1000);
@@ -89,6 +121,7 @@ var InterfaceFunctions = function()
                      if( args.cbFunc )
                         args.cbFunc(args.cbArg);
                  }, {cbFunc:cbFunc, cbArg:cbArg});
+        }
     }
 }
 

--- a/js/interface_localization.js
+++ b/js/interface_localization.js
@@ -165,7 +165,16 @@ if(preferredLanguage == "en"){
       "Terminate Daemon:": "Terminate Daemon:",
       "Exit": "Exit",
       "Save Changes": "Save Changes",
-      "Secret key:": "Secret key:"
+      "Secret key:": "Secret key:",
+      "You have to log in to post messages.": "You have to log in to post messages.",
+      "You have to log in to post replies.": "You have to log in to post replies.",
+      "You have to log in to retransmit messages.": "You have to log in to retransmit messages.",
+      "You have to log in to use direct messages.": "You have to log in to use direct messages.",
+      "You have to log in to follow users.": "You have to log in to follow users.",
+      "You are not following anyone because you are not logged in.": "You are not following anyone because you are not logged in.",
+      "You don't have any followers because you are not logged in.": "You don't have any followers because you are not logged in.",      
+      "No one can mention you because you are not logged in.": "No one can mention you because you are not logged in.",
+      "You don't have any profile because you are not logged in.": "You don't have any profile because you are not logged in."
     };
 }
 if(preferredLanguage == "es"){

--- a/js/interface_profile-edit.js
+++ b/js/interface_profile-edit.js
@@ -22,7 +22,7 @@ function initProfileEdit() {
 
     initUser( function() {
         if( !defaultScreenName ) {
-            alert("Username undefined, login required.");
+            alert(polyglot.t("username_undefined"));
             $.MAL.goLogin();
             return;
         }

--- a/js/twister_directmsg.js
+++ b/js/twister_directmsg.js
@@ -110,6 +110,11 @@ function newDirectMsg(msg,  dm_screenname) {
 //dispara o modal de direct messages
 function directMessagesPopup()
 {
+    if(!defaultScreenName)
+    {
+      alert(polyglot.t("You have to log in to use direct messages."));
+      return;
+    }
     var directMessagesClass = "directMessages";
     openModal( directMessagesClass );
 
@@ -140,6 +145,11 @@ function hideDmSnippetShowDmThread()
 
 function directMessagesWithUserPopup()
 {
+    if(!defaultScreenName)
+    {
+      alert(polyglot.t("You have to log in to use direct messages."));
+      return;
+    }
     var $userInfo = $(this).closest("[data-screen-name]");
     var dm_screenname = $userInfo.attr("data-screen-name");
     openDmWithUserModal( dm_screenname );

--- a/js/twister_following.js
+++ b/js/twister_following.js
@@ -437,6 +437,12 @@ function userClickFollow(e) {
     var $this = $(this);
     var $userInfo = $this.closest("[data-screen-name]");
     var username = $userInfo.attr("data-screen-name");
+    
+    if(!defaultScreenName)
+    {
+      alert(polyglot.t("You have to log in to follow users."));
+      return;
+    }
 
     follow(username, true, function() {
         // delay reload so dhtput may do it's job

--- a/js/twister_formatpost.js
+++ b/js/twister_formatpost.js
@@ -90,7 +90,14 @@ function postToElem( post, kind ) {
             replyTo += "@" + mentions[i] + " ";
         }
     }
-    elem.find(".post-area-new textarea").attr("placeholder", polyglot.t("reply_to", { fullname: replyTo })+ "...");
+    if(!defaultScreenName)
+    {
+	elem.find(".post-area-new textarea").attr("placeholder", polyglot.t("You have to log in to post replies."));
+    }
+    else
+    {
+	elem.find(".post-area-new textarea").attr("placeholder", polyglot.t("reply_to", { fullname: replyTo })+ "...");
+    }
     elem.find(".post-area-new textarea").attr("data-reply-to",replyTo);
     postData.attr("data-reply-to",replyTo);
 

--- a/js/twister_network.js
+++ b/js/twister_network.js
@@ -265,6 +265,11 @@ function initInterfaceNetwork() {
                 initDMsCount();
             });
         }
+        else
+	{
+	    $(".userMenu-profile > a").text(polyglot.t("Login"));
+	    $(".userMenu-profile > a").attr("href","login.html");
+	}
     });
     networkUpdate();
     setInterval("networkUpdate()", 2000);

--- a/js/twister_timeline.js
+++ b/js/twister_timeline.js
@@ -204,7 +204,7 @@ function processReceivedPosts(req, posts)
 // request timeline update for a given list of users
 function requestTimelineUpdate(mode, count, timelineUsers, getspam)
 {
-    if( _refreshInProgress )
+    if( _refreshInProgress || !defaultScreenName)
         return;
     $.MAL.postboardLoading();
     _refreshInProgress = true;


### PR DESCRIPTION
Implementation of feature request miguelfreitas/twister-core#143. This is intended to lower the entry barrier for new users, who can now start browsing right away, and decide to register after the UI tells them they need to log in to be able to use active functions like replying, posting, and following others. It can also be used to run public read-only servers, as Ira and Mpancorbo wanted.

To test it, you can either remove all user accounts from the testing instance, or run it on a freshly installed one. The guest mode is used automatically when no accounts are available.
