### PR TITLE
Disable the Direct Messages button and add screen name behind fullname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/nbproject
+/nbproject/private/

--- a/css/style.css
+++ b/css/style.css
@@ -920,6 +920,13 @@ ol.toptrends-list {
     text-decoration: none;
     padding-left: 2px;
 }
+
+.post-info-screen-name {
+	display: inline;
+	font-size: 12px;
+	color: rgba(0,0,0,.5);
+}
+
 .post-info-tag
 {
     font-style: italic;

--- a/home.html
+++ b/home.html
@@ -224,6 +224,7 @@
             <div class="post-photo"><img class="avatar" src="img/grayed_avatar_placeholder_24.png" alt="user-photo"/></div>
             <div class="post-info">
                 <a href="#" class="post-info-name open-profile-modal"></a>
+				<div class="post-info-screen-name">@<b></b></div>
                 <span class="post-info-tag"></span>
                 <a class="post-info-time"></a>
             </div>
@@ -404,7 +405,7 @@
                 </ul>
               </div>
               <button class="followButton follow" href="#">Follow</button>
-              <button class="direct-messages-with-user" href="#">Direct Messages</button>
+              <button class="direct-messages-with-user disabled" disabled="disabled" href="#">Direct Messages</button>
             </div>
             <div class="who-follow"></div>
           </div>

--- a/js/interface_common.js
+++ b/js/interface_common.js
@@ -125,6 +125,15 @@ function openProfileModal(e)
             unfollow(username);
         });
     };
+	
+	var dmButton = $('.profile-card button.direct-messages-with-user');
+	if ($('.profile-card .profile-card-main .profile-name').hasClass('isFollowing')){
+		dmButton.removeClass('disabled');
+		dmButton.removeAttr('disabled');
+	}else{
+		dmButton.addClass('disabled');
+		dmButton.attr('disabled', 'disabled');
+	}
 }
 
 function newHashtagModal(hashtag) {

--- a/js/twister_formatpost.js
+++ b/js/twister_formatpost.js
@@ -77,6 +77,9 @@ function postToElem( post, kind, promoted ) {
         postData.find('.post-expand').text(polyglot.t("Show conversation"));
     }
 
+	var postScreenName = elem.find(".post-info-screen-name b");
+	postScreenName.text(n);
+
     var postInfoName = elem.find(".post-info-name");
     postInfoName.attr('href',$.MAL.userUrl(n));
     postInfoName.text(n);

--- a/theme_calm/css/style.css
+++ b/theme_calm/css/style.css
@@ -1105,6 +1105,13 @@ textarea.splited-post {
     text-decoration: none;
     padding-left: 2px;
 }
+
+.post-info-screen-name {
+	display: inline;
+	font-size: 12px;
+	color: rgba(0,0,0,.5);
+}
+
 .post-info-tag
 {
     font-style: italic;


### PR DESCRIPTION
Disable the "Direct Messages" button that in the profile modal while the
profile is not your follower.

Add the screen name behind the full name in the post, because the full name is usually far different from the screen name.
