### PR TITLE
Add a dummy Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+# Dummy Dockerfile
+# This is just needed to trigger rebuilds of the complete twister image via the Docker registry hub.
+FROM busybox
+ADD . /twister-html


### PR DESCRIPTION
Currently, the [twister build](https://registry.hub.docker.com/u/miguelfreitas/twister/) is rebuilt automatically at the Docker hub as the twister-core Github repository is updated. But the build also adds twister-html from its separate Github repository. Unfortunately, that means the Docker image won't be automatically updated if twister-html is updated.

This is a request to change the situation. The plan:
1. Merge this PR so this project has a (dummy) Dockerfile.
2. Create a new automated build for this repository at the [Docker hub](https://hub.docker.com/).
3. At the [main twister image](https://registry.hub.docker.com/u/miguelfreitas/twister/), click on _Repository Links_ in the sidebar. Add the newly created twister-html image as a link.

Afterwards, every change to the twister-html repository will trigger a build of the new (dummy) twister-html image at the hub. As a result of that, a new build of the main twister image will be triggered. This means every change of either twister-core or twister-html will automatically create a new main image. Just what we want!

@miguelfreitas, as you are the owner of both the repositories, you are the only one who is able to set this up at the Docker hub. Would be cool if you found some time for that. Thanks in advance!
