### PR TITLE
Break #double#hashtags at the #.

### DIFF
--- a/js/twister_formatpost.js
+++ b/js/twister_formatpost.js
@@ -322,7 +322,7 @@ function _extractHashtag(s) {
     var hashtag = "";
     s = reverseHtmlEntities(s);
     for( var i = 0; i < s.length; i++ ) {
-        if( " \n\t.,:/?!;'\"()[]{}*".indexOf(s[i]) < 0 ) {
+        if( " \n\t.,:/?!;'\"()[]{}*#".indexOf(s[i]) < 0 ) {
             hashtag += s[i];
         } else {
             break;


### PR DESCRIPTION
Not sure if this was by design but I would have expected #Double#Hashtag to be broken down into two hashtags. But in line 255 the msg is just sliced based on the starting hash, not based on any of the following ones.
Twitter seems to completely ignore these doubletags. so I guess it is a matter of taste...

also I am unsure if this strategy shows up in other places of the JS or even in core..?
