### PR TITLE
Fix #204 - Duplicated postboard-news element

### DIFF
--- a/home.html
+++ b/home.html
@@ -203,7 +203,6 @@
         <!-- User's pic --> 
         <div class="profile-photo"><img src="img/genericPerson.png" alt="user-photo"/></div>
       </div>
-      <div class="postboard-news" style="display:none"></div>
       <!-- END postboard-top --> 
 
 


### PR DESCRIPTION
New posts are announced with the .postboard-news button. But home.html also contains a forgotten div with the same css class, so all the same rules apply to it - the new_posts string is filled into it too. This isn't noticed normally, as it is set to display:none, but it can probably be accidentally selected by jQuery and called to “fade in”, causing the duplication glitch that @dryabov noticed.

Fixes issue #204.
