### PR TITLE
Fix custom protocol registration

### DIFF
--- a/js/interface_common.js
+++ b/js/interface_common.js
@@ -404,9 +404,12 @@ function watchHashChange(e)
 function initHashWatching()
 {
     // Register custom protocol handler
-    if (window.navigator && window.navigator.registerProtocolHandler){
+    already_registered = _getResourceFromStorage("twister_protocol_registered");
+    
+    if (window.navigator && window.navigator.registerProtocolHandler && !already_registered){
         var local_twister_url = window.location.protocol + '//' + window.location.host + '/home.html#%s';
         window.navigator.registerProtocolHandler('web+twister', local_twister_url, 'Twister');
+	_putResourceIntoStorage("twister_protocol_registered", true);
     }
 
     // Register hash spy and launch it once


### PR DESCRIPTION
Minor issue: registration of custom protocol handler is performed on each page load. In some versions of Firefox, this causes constant notifications saying “Twister has already been added as an application for web+twister links.”

Solution: before doing it, check if it has already been registered. 
