### PR TITLE
fix multi-byte character hashtag

### DIFF
--- a/js/interface_common.js
+++ b/js/interface_common.js
@@ -174,7 +174,7 @@ function openHashtagModal(e)
 
 function openHashtagModalFromSearch(hashtag)
 {
-    window.location.hash = '#hashtag?hashtag=' + hashtag;
+    window.location.hash = '#hashtag?hashtag=' + encodeURIComponent(hashtag);
 }
 
 function openHashtagModalFromSearchHandler(hashtag)

--- a/js/twister_actions.js
+++ b/js/twister_actions.js
@@ -307,7 +307,7 @@ function requestHashtag(postboard,hashtag,resource, timeoutArgs) {
 }
 
 function processHashtag(postboard, hashtag, data) {
-    if( data && window.location.hash.indexOf(hashtag) != -1 ) {
+    if( data && window.location.hash.indexOf(encodeURIComponent(hashtag)) != -1 ) {
         for( var i = data.length-1; i >= 0; i-- ) {
             var userpost = data[i]["userpost"];
             var key = userpost["n"] + ";" + userpost["time"];


### PR DESCRIPTION
Multi-byte character hashtag has to be encoded by encodeURIComponent for it to work properly.
