### PR TITLE
Fix 2 issues with CPU count for mining

### DIFF
--- a/js/twister_network.js
+++ b/js/twister_network.js
@@ -281,6 +281,7 @@ function interfaceNetworkHandlers() {
     $( ".add-peer").bind( "click", addPeerClick );
     $( ".add-dns").bind( "click", addDNSClick );
     $( "select.genblock").change( setGenerate );
+    $( ".genproclimit").change( setGenerate );
     $( ".update-spam-msg").bind( "click", setSpamMsg );
     $( ".terminate-daemon").bind( "click", exitDaemon )
 }

--- a/js/twister_network.js
+++ b/js/twister_network.js
@@ -10,6 +10,7 @@ var twisterDhtNodes = 0;
 var twisterdBlocks = 0;
 var twisterdLastBlockTime = 0;
 var twisterdConnectedAndUptodate = false;
+var genproclimit = 1;
 
 // ---
 
@@ -178,6 +179,7 @@ function getMiningInfo(cbFunc, cbArg) {
                function(args, ret) {
                    miningDifficulty    = ret.difficulty;
                    miningHashRate      = ret.hashespersec;
+                   genproclimit        = ret.genproclimit;
 
                    $(".mining-difficulty").text(miningDifficulty);
                    $(".mining-hashrate").text(miningHashRate);
@@ -307,7 +309,9 @@ function initInterfaceNetwork() {
     networkUpdate();
     setInterval("networkUpdate()", 2000);
 
-    miningUpdate();
+    miningUpdate( function() {
+        $(".genproclimit").val(genproclimit);
+    });
     setInterval("miningUpdate()", 2000);
 
     getGenerate();


### PR DESCRIPTION
1 - changing CPU count on the network page does not do anything - miguelfreitas/twister-core#281
It was exactly as @nonchip predicted - the CPU count textbox was missing a change handler.

2 - CPU count is not loaded
This is another bug I found - when you are mining on 4 cores, and you open the network page, the textbox says 1 core. I fixed it to load the value from getmininginfo on page load.