### PR TITLE
firefox-searchbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -382,6 +382,8 @@ button.disabled:hover
     margin: 9px 20px 0 0;
     border-radius: 10px;
     border: none;
+    height: 16px;
+    font-size: 0.8125rem;
 }
 .userMenu-search-sugestions
 {

--- a/css/style.css
+++ b/css/style.css
@@ -383,7 +383,7 @@ button.disabled:hover
     border-radius: 10px;
     border: none;
     height: 16px;
-    font-size: 0.8125rem;
+    font-size: 13px;
 }
 .userMenu-search-sugestions
 {


### PR DESCRIPTION
Hi,

This is fixes a ui-glitch that is probably quite rare. Firefox defaults to use the systems default font and font-size for html input fields. I have set my system font size higher than normal and that probably leads to this glitch:

![screenshot from 2015-01-16 17 03 49](https://cloud.githubusercontent.com/assets/3002197/5779263/b3490b6e-9da1-11e4-8113-2926ce7f6993.png)

now it looks as expected (same as in chromium)

![screenshot from 2015-01-16 17 01 44](https://cloud.githubusercontent.com/assets/3002197/5779233/62e9797e-9da1-11e4-8261-acedd2e6df52.png)

Greetings
Tschaul

