### PR TITLE
Fixing duplicate posts when scrolling in profile view

### DIFF
--- a/js/twister_actions.js
+++ b/js/twister_actions.js
@@ -176,7 +176,7 @@ function requestPostRecursively(containerToAppend,username,resource,count,useGet
         if( streamItems.length != 0 ) {
             var lastItem = streamItems.eq(streamItems.length-1);
             resource = "post" + lastItem.find(".post-data").attr("data-lastk");
-            max_id = parseInt(lastItem.find(".post-data").attr("data-id"))-1;
+            max_id = parseInt(lastItem.find(".post-data").attr("data-lastk"));
         }
     }
 


### PR DESCRIPTION
Regarding this conversation: https://twisterio.com/post/chinanet/8122

The problem was that the *requestPostRecursively* function, which gets called when scrolling, got the *max_id* parameter for the *getposts* command from the *data-id* property of the last post in the postboard. If, however, this is a retwisted post this yields the id the of the rewtist*ed* post and not that of the retwist*ing* post (in the postbard). The function now uses the *data-lastk* property which seams to solve the problem.