### PR TITLE
fix of post splitting, $.fn.caret, licenses for caret, franc and notify.js

### DIFF
--- a/js/interface_common.js
+++ b/js/interface_common.js
@@ -764,15 +764,15 @@ function replyTextInput(e) {
             var $tas = tweetForm.find("textarea");
             splitedPostsCount = $tas.length;
             var icurrentta = $tas.index(this); // current textarea $tas index
+            if (splitedPostsCount > 1)
+                var pml = getPostSplitingPML();
+            else
+                var pml = 140;
             var cci = getPostSpittingCI(icurrentta);
             var caretPos = $this.caret();
             var reply_to = $this.attr('data-reply-to');
 
             for (var i = 0; i < $tas.length; i++) {
-                if (splitedPostsCount > 1)
-                    var pml = getPostSplitingPML();
-                else
-                    var pml = 140;
                 if ($tas[i].value.length > pml) {
                     if (pml === 140)
                         pml = getPostSplitingPML();
@@ -802,6 +802,7 @@ function replyTextInput(e) {
 
                         $tas = tweetForm.find("textarea");
                         splitedPostsCount = $tas.length;
+                        pml = getPostSplitingPML();
 
                         $oldta.on('focus', function() {
                             this.style.height = '80px';
@@ -832,6 +833,10 @@ function replyTextInput(e) {
                     }
                     $tas = tweetForm.find("textarea");
                     splitedPostsCount = $tas.length;
+                    if (splitedPostsCount > 1)
+                        pml = getPostSplitingPML();
+                    else
+                        pml = 140;
                     caretPos = -1;
                     if (icurrentta >= i && icurrentta > 0) {
                         icurrentta -= 1;

--- a/js/jQueryPlugins.js
+++ b/js/jQueryPlugins.js
@@ -12,3 +12,83 @@
       return $(this);
    }
 })(jQuery);
+
+(function($) {
+  $.fn.caret = function(pos) {
+    var target = this[0];
+	var isContentEditable = target.contentEditable === 'true';
+    //get
+    if (arguments.length == 0) {
+      //HTML5
+      if (window.getSelection) {
+        //contenteditable
+        if (isContentEditable) {
+          target.focus();
+          var range1 = window.getSelection().getRangeAt(0),
+              range2 = range1.cloneRange();
+          range2.selectNodeContents(target);
+          range2.setEnd(range1.endContainer, range1.endOffset);
+          return range2.toString().length;
+        }
+        //textarea
+        return target.selectionStart;
+      }
+      //IE<9
+      if (document.selection) {
+        target.focus();
+        //contenteditable
+        if (isContentEditable) {
+            var range1 = document.selection.createRange(),
+                range2 = document.body.createTextRange();
+            range2.moveToElementText(target);
+            range2.setEndPoint('EndToEnd', range1);
+            return range2.text.length;
+        }
+        //textarea
+        var pos = 0,
+            range = target.createTextRange(),
+            range2 = document.selection.createRange().duplicate(),
+            bookmark = range2.getBookmark();
+        range.moveToBookmark(bookmark);
+        while (range.moveStart('character', -1) !== 0) pos++;
+        return pos;
+      }
+      // Addition for jsdom support
+      if (target.selectionStart)
+        return target.selectionStart;
+      //not supported
+      return 0;
+    }
+    //set
+    if (pos == -1)
+      pos = this[isContentEditable? 'text' : 'val']().length;
+    //HTML5
+    if (window.getSelection) {
+      //contenteditable
+      if (isContentEditable) {
+        target.focus();
+        window.getSelection().collapse(target.firstChild, pos);
+      }
+      //textarea
+      else
+        target.setSelectionRange(pos, pos);
+    }
+    //IE<9
+    else if (document.body.createTextRange) {
+      if (isContentEditable) {
+        var range = document.body.createTextRange();
+        range.moveToElementText(target);
+        range.moveStart('character', pos);
+        range.collapse(true);
+        range.select();
+      } else {
+        var range = target.createTextRange();
+        range.move('character', pos);
+        range.select();
+      }
+    }
+    if (!isContentEditable)
+      target.focus();
+    return pos;
+  }
+})(jQuery);

--- a/licenses/caret.license
+++ b/licenses/caret.license
@@ -1,0 +1,30 @@
+Copyright (c) 2009, Gideon Sireling
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Gideon Sireling nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/franc.license
+++ b/licenses/franc.license
@@ -1,0 +1,25 @@
+(The MIT License)
+
+Copyright (c) 2014-2015 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2008 Kent S Johnson
+Copyright (c) 2006 Jacob R Rideout <kde@jacobrideout.net>
+Copyright (c) 2004 Maciej Ceglowski
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/notify.js.license
+++ b/licenses/notify.js.license
@@ -1,0 +1,9 @@
+Copyright (c) 2014 Alex Gibson
+
+http://alxgbsn.co.uk/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction except as noted below, including without limitation the rights to use, copy, modify, merge, publish, distribute, and/or sublicense, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE


### PR DESCRIPTION
here is
* improvements of post splitting
  * mostly it's twisting with a caret in tightrope-walking manner
  * now counter shows information related for current textarea
* [$.fn.caret](https://github.com/accursoft/caret) by @accursoft
  * because caret is actually a kind of trouble for browsers
* missing licenses for `caret`, `franc` and `notify.js`