### PR TITLE
Fix "Maximum call stack size exceeded" error

### DIFF
--- a/js/twister_following.js
+++ b/js/twister_following.js
@@ -590,8 +590,11 @@ function processSuggestion(arg, suggestion, followedBy) {
         $list.append(item).show();
         $module.find('.refresh-users').show();
         $module.find('.loading-roller').hide();
-    } else
-        getRandomFollowSuggestion(processSuggestion);
+    } else {
+        setTimeout(function(){
+            getRandomFollowSuggestion(processSuggestion);
+        }, 100);
+    }
 }
 
 function closeSearchDialog()


### PR DESCRIPTION
A dirty hack to wait for loading of wallet users list without "Maximum call stack size exceeded" error. It would be better to call `initWhoToFollow` after `loadFollowing` method is executed, but there is adventure of `setTimeout`: it reduces CPU usage if there are no users to suggest.