### PR TITLE
fix of black modals on chromium based browsers

### DIFF
--- a/js/interface_common.js
+++ b/js/interface_common.js
@@ -28,6 +28,8 @@ function openModal(modal) {
     else
         modal.content = modal.self.find('.modal-content');
 
+    modal.self.prependTo('body').fadeIn('fast');
+
     if (modal.classBase === '.modal-wrapper') {
         modal.content.outerHeight(modal.self.height() - modal.self.find('.modal-header').outerHeight());
 
@@ -38,8 +40,6 @@ function openModal(modal) {
             modal.self.css('margin-top', - windowHeight / 2);
         }
     }
-
-    modal.self.prependTo('body').fadeIn('fast');
 
     return modal;
 }


### PR DESCRIPTION
looks like we can get height of elements which not appended to body at least once in Firefox only or something. I tested it on Opera Blink too when I have cooked a things but in a last moment I changed order of operations because thought that manipulation with not appended elements are bit faster (so current patch is a kind of revert too) but I forgot to try it. sorry about that.