### PR TITLE
Add shortcut parameter inside favicon html code of all html files

### DIFF
--- a/abort.html
+++ b/abort.html
@@ -19,12 +19,12 @@
     <script src="js/twister_network.js"></script>
     <script src="js/interface_common.js"></script>
     <script>changeStyle();</script>
-    <link rel="icon" type="image/png" href="img/twister_mini.png" />
+    <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
   </head>
 
   <body>
-    
-  <!-- MENU SUPERIOR INIT --> 
+
+  <!-- MENU SUPERIOR INIT -->
   <nav class="userMenu">
   </nav>
   <!-- MENU SUPERIOR END -->

--- a/following.html
+++ b/following.html
@@ -27,7 +27,7 @@
     <script src="js/interface_common.js"></script>
     <script src="js/jquery.textcomplete.min.js"></script>
 
-    <link rel="icon" type="image/png" href="img/twister_mini.png" />
+    <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
   </head>
   <body>
   <!-- MENU SUPERIOR INIT -->

--- a/home.html
+++ b/home.html
@@ -29,7 +29,7 @@
     <script src="js/interface_home.js"></script>
     <script src="js/jquery.textcomplete.min.js"></script>
 
-    <link rel="icon" type="image/png" href="img/twister_mini.png" />
+    <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
   </head>
   <body>
   <!-- MENU SUPERIOR INIT -->

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 
-<html> 
-<head> 
-  <meta charset="utf-8" /> 
+<html>
+<head>
+  <meta charset="utf-8" />
 
   <title>twister</title>
-  
+
   <meta name="viewport" content="width=device-width, user-scalable=no"/>
 
   <link rel="stylesheet" href="css/jquery.mobile-1.3.2.min.css" />
@@ -13,9 +13,9 @@
   <script src="js/jquery.mobile.router.min.js"></script>
   <script src="js/jquery.mobile-1.3.2.min.js"></script>
 
-  <link rel="icon" type="image/png" href="img/twister_mini.png" />
-</head> 
-<body> 
+  <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
+</head>
+<body>
 
 <div id="index" data-role="page">
   <div data-role="header" data-position="fixed" data-nobackbtn="true">
@@ -29,5 +29,5 @@
 </div>
 
 
-</body> 
-</html> 
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -21,7 +21,7 @@
     <script src="js/polyglot.min.js"></script>
     <script src="js/interface_localization.js"></script>
 
-    <link rel="icon" type="image/png" href="img/twister_mini.png" />
+    <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
   </head>
   <body>
   <!-- MENU SUPERIOR INIT -->

--- a/network.html
+++ b/network.html
@@ -23,7 +23,7 @@
     <script src="js/twister_network.js"></script>
     <script src="js/interface_common.js"></script>
 
-    <link rel="icon" type="image/png" href="img/twister_mini.png" />
+    <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
   </head>
 
   <body>

--- a/options.html
+++ b/options.html
@@ -21,6 +21,8 @@
     <script src="js/interface_login.js"></script>
     <script src="js/polyglot.min.js"></script>
     <script src="js/interface_localization.js"></script>
+
+    <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
   </head>
 
   <body>

--- a/profile-edit.html
+++ b/profile-edit.html
@@ -23,7 +23,7 @@
     <script src="js/interface_common.js"></script>
     <script src="js/interface_profile-edit.js"></script>
 
-    <link rel="icon" type="image/png" href="img/twister_mini.png" />
+    <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
   </head>
 
   <body>

--- a/tmobile.html
+++ b/tmobile.html
@@ -37,7 +37,7 @@
     <script src="js/tmobile.js?vr=10"></script>
     <script src="js/jpeg_encoder_basic.js"></script>
 
-  <link rel="icon" type="image/png" href="img/twister_mini.png" />
+  <link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
 </head>
 <body>
 


### PR DESCRIPTION
To be compatible everywhere, the code for favicon should be like this :
```
<link rel="shortcut icon" type="image/png" href="img/twister_mini.png" />
```

I just modify the 9 html files in this way (and my editor removed unecessary spaces)