### PR TITLE
Fix the problem defaultScreenName can be stored as Number

### DIFF
--- a/js/twister_user.js
+++ b/js/twister_user.js
@@ -84,7 +84,7 @@ function loadScreenName() {
 }
 
 function saveScreenName() {
-    $.localStorage.set("defaultScreenName", defaultScreenName);
+    $.localStorage.set("defaultScreenName", '"' + defaultScreenName + '"');
 }
 
 


### PR DESCRIPTION
`$.localStorage.set` can interpret the second argument as a JSON string, so:

~~~js
$.localStorage.set("foo", "1234");
$.localStorage.get("foo"); // => 1234
typeof $.localStorage.get("foo"); // => "number"
~~~

This prevents users whose screen name consists only digits (like `@928`) from logging in because his/her screen name doesn't match with the stored user name (https://github.com/miguelfreitas/twister-html/blob/8394d8f0f22f7bf2305ca9326d23e003968512b9/js/twister_user.js#L31).
~~~js
['928'].indexOf(928); // => -1
~~~

By merging this pull request, the stored value is assured to be a string value, which fixes this problem.