### PR TITLE
Make sure defaultScreenName is loaded as a string value

### DIFF
--- a/js/twister_user.js
+++ b/js/twister_user.js
@@ -79,7 +79,7 @@ function loadWalletlUsers(cbFunc, cbArg) {
 
 function loadScreenName() {
     if( $.localStorage.isSet("defaultScreenName") ) {
-        defaultScreenName = $.localStorage.get("defaultScreenName");
+        defaultScreenName = $.localStorage.get("defaultScreenName").toString();
     }
 }
 


### PR DESCRIPTION
This fixes the problem that users with screen name consisting only digit characters cannot login.
See #342.