### PR TITLE
Fix "Save Changes" popup

### DIFF
--- a/profile-edit.html
+++ b/profile-edit.html
@@ -20,6 +20,7 @@
     <script src="js/twister_network.js"></script>
     <script src="js/twister_following.js"></script>
     <script src="js/twister_newmsgs.js"></script>
+    <script src="js/twister_formatpost.js"></script>
     <script src="js/interface_common.js"></script>
     <script src="js/interface_profile-edit.js"></script>
 


### PR DESCRIPTION
`htmlFormatMsg()` from twister_formatpost.js is used by `confirmPopup()` in interface_common.js