### PR TITLE
fix internal image preview

### DIFF
--- a/js/interface_common.js
+++ b/js/interface_common.js
@@ -1431,7 +1431,7 @@ function postExpandFunction(e, postLi) {
         var originalLi = $('<li/>', {class: 'module post original'}).appendTo(itemOl)
             .append(originalPost);
 
-        setPostImagePreview(postExpandedContent, originalPost.find('a[rel="nofollow"]'));
+        setPostImagePreview(postExpandedContent, originalPost.find('a[rel^="nofollow"]'));
 
         postExpandedContent.slideDown('fast');
 


### PR DESCRIPTION
adding ```noreferrer``` to link templates (6ff3252148dc85618b394a4fb05fa43bc2cd5d14) has broken the image preview...